### PR TITLE
Add quagga-view router type to support multi-instance Quagga

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,7 @@ the specific documentation for your router. Possible values are:
   * cisco **or** ios
   * bird
   * quagga **or** zebra
+  * quagga-view [see quagga-view.md](quagga-view.md)
 
 It is also highly recommended to specify a source interface ID to be used by
 the router when it will try to ping or traceroute a destination. This is done

--- a/docs/quagga-view.md
+++ b/docs/quagga-view.md
@@ -1,0 +1,52 @@
+# Looking Glass: Configuration Options
+
+## Quagga BGP views
+Quagga supports multiple instances called "views", [as seen here](http://www.nongnu.org/quagga/docs/docs-multi/BGP-instance-and-view.html)
+
+To be able to view route information by view, the show commands change
+
+Where view name is EXAMPLE, we need to support the following commands
+  * IPv4: `show ip bgp view EXAMPLE`
+  * IPv6: `show bgp view EXAMPLE`
+
+
+
+## quagga-view router type
+If using a view in a Quagga router set the type to "quagga-view"
+
+```php
+$config['routers']['router1']['type'] = 'quagga-view';
+```
+
+You will also need to set the view name
+
+```php
+$config['routers']['router1']['view'] = 'EXAMPLE';
+```
+
+This tells looking-glass to issue the comamnd (`show ip bgp view EXAMPLE x.x.x.x`)
+
+You can have multiple views per Quagga router, just tell looking-glass
+to use a different name (router2),  and change the 'view'
+
+
+```php
+$config['routers']['router1']['host'] = 'r1.example.net';
+$config['routers']['router1']['type'] = 'quagga-view';
+$config['routers']['router1']['desc'] = 'Router 1 View 1';
+// The Quagga view to use
+$config['routers']['router1']['view'] = 'VIEW1';
+
+
+// Same Quagga router (r1) but we tell the Looking Glass
+// to treat it as a separate router by calling it router2
+// only the 'view' has changed!
+
+$config['routers']['router2']['host'] = 'r1.example.net';  // same router!
+$config['routers']['router2']['type'] = 'quagga-view';
+$config['routers']['router2']['desc'] = 'Router 1 View 2';
+// The Quagga view to use
+$config['routers']['router2']['view'] = 'VIEW2';  // different view!
+```
+
+**If you do not define the 'view',  Quagga will use the default table!**

--- a/routers/quaggaview.php
+++ b/routers/quaggaview.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * Looking Glass - An easy to deploy Looking Glass
+ * Copyright (C) 2014-2016 Guillaume Mazoyer <gmazoyer@gravitons.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+require_once('router.php');
+require_once('includes/utils.php');
+
+final class QuaggaView extends Router {
+  protected function build_ping($destination) {
+    $ping = null;
+
+    if (match_hostname($destination)) {
+      $hostname = $destination;
+      $destination = hostname_to_ip_address($hostname, $this->config);
+
+      if (!$destination) {
+        throw new Exception('No record found for '.$hostname);
+      }
+    }
+
+    if (match_ipv6($destination)) {
+      $ping = 'ping6 '.$this->global_config['tools']['ping_options'].' '.
+        (isset($hostname) ? $hostname : $destination);
+    } else if (match_ipv4($destination)) {
+      $ping = 'ping '.$this->global_config['tools']['ping_options'].' '.
+        (isset($hostname) ? $hostname : $destination);
+    } else {
+      throw new Exception('The parameter does not resolve to an IP address.');
+    }
+
+    if (($ping != null) && $this->has_source_interface_id()) {
+      if (match_ipv6($destination) &&
+          ($this->get_source_interface_id('ipv6') != null)) {
+        $ping .= ' '.$this->global_config['tools']['ping_source_option'].' '.
+          $this->get_source_interface_id('ipv6');
+      } else if (match_ipv4($destination) &&
+          ($this->get_source_interface_id('ipv4') != null)) {
+        $ping .= ' '.$this->global_config['tools']['ping_source_option'].' '.
+          $this->get_source_interface_id('ipv4');
+      }
+    }
+
+    return $ping;
+  }
+
+  protected function build_traceroute($destination) {
+    $traceroute = null;
+
+    if (match_hostname($destination)) {
+      $hostname = $destination;
+      $destination = hostname_to_ip_address($hostname, $this->config);
+
+      if (!$destination) {
+        throw new Exception('No record found for '.$hostname);
+      }
+    }
+
+    if (match_ipv6($destination)) {
+      $traceroute = $this->global_config['tools']['traceroute6'].' '.
+        $this->global_config['tools']['traceroute_options'].' '.
+        (isset($hostname) ? $hostname : $destination);
+    } else if (match_ipv4($destination)) {
+      $traceroute = $this->global_config['tools']['traceroute4'].' '.
+        $this->global_config['tools']['traceroute_options'].' '.
+        (isset($hostname) ? $hostname : $destination);
+    } else {
+      throw new Exception('The parameter does not resolve to an IP address.');
+    }
+
+    if (($traceroute != null) && $this->has_source_interface_id()) {
+      if (match_ipv6($destination) &&
+          ($this->get_source_interface_id('ipv6') != null)) {
+        $traceroute .= ' '.
+          $this->global_config['tools']['traceroute_source_option'].' '.
+          $this->get_source_interface_id('ipv6');
+      } else if (match_ipv4($destination) &&
+          ($this->get_source_interface_id('ipv4') != null)) {
+        $traceroute .= ' '.
+          $this->global_config['tools']['traceroute_source_option'].' '.
+          $this->get_source_interface_id('ipv4');
+      }
+    }
+
+    return $traceroute;
+  }
+
+  protected function build_commands($command, $parameter) {
+    $commands = array();
+
+    $vtysh = 'vtysh -c "';
+
+    $view = $this->config['view'];
+
+    switch ($command) {
+      case 'bgp':
+        if (match_ipv6($parameter, false)) {
+          $commands[] = $vtysh.'show bgp view '.$view.' '.$parameter.'"';
+        } else if (match_ipv4($parameter, false)) {
+          $commands[] = $vtysh.'show ip bgp view '.$view.' '.$parameter.'"';
+        } else {
+          throw new Exception('The parameter is not an IP address.');
+        }
+        break;
+
+      case 'as-path-regex':
+        if (match_aspath_regex($parameter)) {
+          if (!$this->config['disable_ipv6']) {
+            $commands[] = $vtysh.'show ipv6 bgp regexp '.$parameter.'"';
+          }
+          if (!$this->config['disable_ipv4']) {
+            $commands[] = $vtysh.'show ip bgp regexp '.$parameter.'"';
+          }
+        } else {
+          throw new Exception('The parameter is not an AS-Path regular expression.');
+        }
+        break;
+
+      case 'as':
+        if (match_as($parameter)) {
+          if (!$this->config['disable_ipv6']) {
+            $commands[] = $vtysh.'show ipv6 bgp regexp ^'.$parameter.'_'.'"';
+          }
+          if (!$this->config['disable_ipv4']) {
+            $commands[] = $vtysh.'show ip bgp regexp ^'.$parameter.'_'.'"';
+          }
+        } else {
+          throw new Exception('The parameter is not an AS number.');
+        }
+        break;
+
+      case 'ping':
+        try {
+          $commands[] = $this->build_ping($parameter);
+        } catch (Exception $e) {
+          throw $e;
+        }
+        break;
+
+      case 'traceroute':
+        try {
+          $commands[] = $this->build_traceroute($parameter);
+        } catch (Exception $e) {
+          throw $e;
+        }
+        break;
+
+      default:
+        throw new Exception('Command not supported.');
+    }
+
+    return $commands;
+  }
+}
+
+// End of quagga.php

--- a/routers/router.php
+++ b/routers/router.php
@@ -25,6 +25,7 @@ require_once('bird.php');
 require_once('cisco.php');
 require_once('juniper.php');
 require_once('quagga.php');
+require_once('quaggaview.php');
 require_once('includes/utils.php');
 require_once('auth/authentication.php');
 
@@ -177,6 +178,9 @@ abstract class Router {
       case 'quagga':
       case 'zebra':
         return new Quagga($config, $router_config, $id, $requester);
+        
+      case 'quagga-view':
+        return new QuaggaView($config, $router_config, $id, $requester);
 
       default:
         print('Unknown router type "'.$router_config['type'].'".');


### PR DESCRIPTION
This PR adds a `quagga-view` router type.    This is still Quagga,  but using the multi-instance capabilities to allow one Quagga node,  to have different BGP 'views'.   This requires some different show command syntax, so I added this in as a new class `quagga-view` extending `Router`

You can view an example here https://lg.netops.cloud.twc.net/

#### Quagga BGP views
Quagga supports multiple instances called "views", [as seen here](http://www.nongnu.org/quagga/docs/docs-multi/BGP-instance-and-view.html)

To be able to view route information by view, the show commands change

Where view name is EXAMPLE, we need to support the following commands
  * IPv4: `show ip bgp view EXAMPLE`
  * IPv6: `show bgp view EXAMPLE`