### PR TITLE
Construct frontpage from config items better

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,13 @@ $config['frontpage']['order'] = array('routers', 'commands', 'parameter', 'butto
 ```
 Sets the order of the sections that are displayed.
 
+```php
+$config['frontpage']['router_count'] = 5;
+```
+Sets the number of routers to show on the front page before the list scrolls. If
+set to a positive integer, then that number of routers will be shown, otherwise
+the list will show all routers.
+
 ### Contact
 
 ```php

--- a/includes/config.defaults.php
+++ b/includes/config.defaults.php
@@ -69,7 +69,9 @@ $config = array(
     // Show visitor IP address
     'show_visitor_ip' => true,
     // Frontpage order you can use: routers, commands, parameter, buttons
-    'order' => array('routers', 'commands', 'parameter', 'buttons')
+    'order' => array('routers', 'commands', 'parameter', 'buttons'),
+    // Number of routers to show on frontpage
+    'router_count' => 5
   ),
 
   // Contact (both null for no contact)

--- a/index.php
+++ b/index.php
@@ -90,7 +90,7 @@ final class LookingGlass {
     print('<div class="form-group">');
     print('<label for="input-param">Parameter</label>');
     print('<div class="input-group">');
-    erint('<input class="form-control" name="parameter" id="input-param" autofocus />');
+    print('<input class="form-control" name="parameter" id="input-param" autofocus />');
     print('<div class="input-group-append">');
     print('<button type="button" class="btn btn-info" data-toggle="modal" data-target="#help">');
     print('<i class="fas fa-question-circle"></i> Help');

--- a/index.php
+++ b/index.php
@@ -37,6 +37,7 @@ final class LookingGlass {
     $this->contact = $config['contact'];
     $this->misc = $config['misc'];
     $this->routers = $config['routers'];
+    $this->doc = $config['doc'];
   }
 
   private function render_routers() {
@@ -69,11 +70,11 @@ final class LookingGlass {
     print('<div class="form-group">');
     print('<label for="query">Command to issue</label>');
     print('<select size="5" class="form-control" name="query" id="query">');
-    print('<option value="bgp" selected="selected">show route IP_ADDRESS</option>');
-    print('<option value="as-path-regex">show route as-path-regex AS_PATH_REGEX</option>');
-    print('<option value="as">show route AS</option>');
-    print('<option value="ping">ping IP_ADDRESS|HOSTNAME</option>');
-    print('<option value="traceroute">traceroute IP_ADDRESS|HOSTNAME</option>');
+    $selected = ' selected="selected"';
+    foreach (array_keys($this->doc) as $cmd) {
+      print('<option value="'.$cmd.'"'.$selected.'>'.$this->doc[$cmd]['command'].'</option>');
+      $selected = '';
+    }
     print('</select>');
     print('</div>');
   }

--- a/index.php
+++ b/index.php
@@ -40,10 +40,17 @@ final class LookingGlass {
     $this->doc = $config['doc'];
   }
 
+  private function router_count() {
+    if ($this->frontpage['router_count'] > 0)
+      return $this->frontpage['router_count'];
+    else
+      return count($this->routers);
+  }
+
   private function render_routers() {
     print('<div class="form-group">');
     print('<label for="routers">Router to use</label>');
-    print('<select size="'.$this->frontpage['router_count'].'" class="form-control" name="routers" id="routers">');
+    print('<select size="'.router_count().'" class="form-control" name="routers" id="routers">');
 
     $first = true;
     foreach (array_keys($this->routers) as $router) {

--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@ final class LookingGlass {
   private function render_routers() {
     print('<div class="form-group">');
     print('<label for="routers">Router to use</label>');
-    print('<select size="5" class="form-control" name="routers" id="routers">');
+    print('<select size="'.$this->frontpage['router_count'].'" class="form-control" name="routers" id="routers">');
 
     $first = true;
     foreach (array_keys($this->routers) as $router) {

--- a/index.php
+++ b/index.php
@@ -50,7 +50,7 @@ final class LookingGlass {
   private function render_routers() {
     print('<div class="form-group">');
     print('<label for="routers">Router to use</label>');
-    print('<select size="'.router_count().'" class="form-control" name="routers" id="routers">');
+    print('<select size="'.$this->router_count().'" class="form-control" name="routers" id="routers">');
 
     $first = true;
     foreach (array_keys($this->routers) as $router) {
@@ -90,7 +90,7 @@ final class LookingGlass {
     print('<div class="form-group">');
     print('<label for="input-param">Parameter</label>');
     print('<div class="input-group">');
-    print('<input class="form-control" name="parameter" id="input-param" autofocus />');
+    erint('<input class="form-control" name="parameter" id="input-param" autofocus />');
     print('<div class="input-group-append">');
     print('<button type="button" class="btn btn-info" data-toggle="modal" data-target="#help">');
     print('<i class="fas fa-question-circle"></i> Help');


### PR DESCRIPTION
Hi

These two commits allow the front page to be built from the config rather than using fixed values.

1. Allow the config to specify the length of the router select, default to 5
2. Complete the commands select using the commands from the doc, selecting the first.

These were changes required for respawner/looking-glass to fit our needs; I have constructed them to maintain the existing functionality as default.

If you have any comments I'd be happy to address them, otherwise I hope you'll consider accepting this request.

Thanks
Nat