### PR TITLE
Support Extreme/Brocade NetIron routers, fix an eternal while loop in telnet.php

### DIFF
--- a/auth/telnet.php
+++ b/auth/telnet.php
@@ -54,8 +54,11 @@ final class Telnet extends Authentication {
     fputs($this->connection, $command."\r\n");
 
     $data = '';
-    while(!feof(!$this->connection)) {
+    while(substr($data, -1) != '#' &&
+        substr($data, -1) != '>')
+    {
       $data .= fread($this->connection, 4096);
+      $data = rtrim($data, " ");
     }
 
     $this->disconnect();

--- a/config.php.example
+++ b/config.php.example
@@ -24,6 +24,8 @@ $config['frontpage']['disclaimer'] = 'This is a disclaimer!';
 // Things to remove from the output (PHP compatible regex)
 $config['filters'][] = '/(client1|client2)/';
 $config['filters'][] = '/^NotToShow/';
+// If telnet is used in combination with extreme_netiron, uncomment the following filter
+//$config['filters'][] = '/([^\x20-\x7E]|User|Please|Disable|telnet|^\s*$)/';
 
 // Routers definitions
 
@@ -34,7 +36,7 @@ $config['routers']['router1']['host'] = 'r1.example.net';
 $config['routers']['router1']['user'] = 'readonlyuser';
 // The password of the given user
 $config['routers']['router1']['pass'] = 'readonlypassword';
-// The authentication mecanism to use (can be ssh-password or telnet)
+// The authentication mechanism to use (can be ssh-password or telnet)
 $config['routers']['router1']['auth'] = 'ssh-password';
 // The router type (can be cisco, ios, juniper or junos)
 $config['routers']['router1']['type'] = 'juniper';
@@ -52,7 +54,7 @@ $config['routers']['router2']['user'] = 'readonlyuser';
 $config['routers']['router2']['private_key'] = '/home/user/.ssh/key';
 // The passphrase of the key (optional if the key has no passphrase)
 $config['routers']['router2']['pass'] = 'mypassphrase';
-// The authentication mecanism to use (ssh-key for SSH based on keys)
+// The authentication mechanism to use (ssh-key for SSH based on keys)
 $config['routers']['router2']['auth'] = 'ssh-key';
 // The router type (can be cisco, ios, juniper or junos)
 $config['routers']['router2']['type'] = 'juniper';
@@ -68,7 +70,7 @@ $config['routers']['router3']['host'] = 'r3.example.net';
 $config['routers']['router3']['user'] = 'birduser';
 // The password of the given user
 $config['routers']['router3']['pass'] = 'birduserpassword';
-// The authentication mecanism to use (can be ssh-password or ssh-key)
+// The authentication mechanism to use (can be ssh-password or ssh-key)
 $config['routers']['router3']['auth'] = 'ssh-password';
 // The router type (can only be bird)
 $config['routers']['router3']['type'] = 'bird';
@@ -84,7 +86,7 @@ $config['routers']['router4']['host'] = 'r4.example.net';
 $config['routers']['router4']['user'] = 'openbgpduser';
 // The password of the given user
 $config['routers']['router4']['pass'] = 'openbgpduserpassword';
-// The authentication mecanism to use (can be ssh-password or ssh-key)
+// The authentication mechanism to use (can be ssh-password or ssh-key)
 $config['routers']['router4']['auth'] = 'ssh-password';
 // The router type (can only be openbgpd)
 $config['routers']['router4']['type'] = 'openbgpd';
@@ -92,6 +94,23 @@ $config['routers']['router4']['type'] = 'openbgpd';
 $config['routers']['router4']['source-interface-id'] = '192.168.1.1';
 // The router description to be displayed in the router list
 $config['routers']['router4']['desc'] = 'OpenBGPd Router';
+
+// Router based on Extreme NetIron
+// The hostname or the IP address
+$config['routers']['router5']['host'] = 'r5.example.net';
+// The user to use to connect to the router
+$config['routers']['router5']['user'] = 'readonlyuser';
+// The password of the given user
+$config['routers']['router5']['pass'] = 'readonlypassword';
+// The authentication mechanism to use (must be telnet)
+$config['routers']['router5']['auth'] = 'telnet';
+// The router type (can only be extreme_netiron)
+$config['routers']['router5']['type'] = 'extreme_netiron';
+// The router source interface to be used
+$config['routers']['router5']['source-interface-id']['ipv4'] = '192.168.1.1';
+$config['routers']['router5']['source-interface-id']['ipv6'] = '2001:db8::1';
+// The router description to be displayed in the router list
+$config['routers']['router5']['desc'] = 'Example\'s router 5';
 
 // If running on *BSD, disable '-A' which is non-existent
 $config['tools']['ping_options'] = '-c 5';

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,14 +113,15 @@ interact with it.
 ```php
 $config['routers']['router1']['type'] = 'juniper';
 ```
-The router type can be Juniper, Cisco (IOS or IOS-XR), Quagga, BIRD, OpenBGPd
-or Vyatta/VyOS/EdgeOS. You can take a look at the specific documentation for
-your router.
+The router type can be Juniper, Cisco (IOS or IOS-XR), Extreme (NetIron), Quagga,
+BIRD, OpenBGPd or Vyatta/VyOS/EdgeOS. You can take a look at the specific
+documentation for your router.
 Possible values are:
 
   * juniper **or** junos
   * cisco **or** ios
   * ios-xr **or** iosxr
+  * extreme_netiron
   * bird
   * quagga **or** zebra
   * openbgpd
@@ -139,9 +140,9 @@ interface), and with:
 $config['routers']['router1']['source-interface-id']['ipv6'] = '2001:db8::1';
 $config['routers']['router1']['source-interface-id']['ipv4'] = '192.168.1.1';
 ```
-for Cisco IOS XR, BIRD and Quagga routers (use your own IP addresses).
-Omitting the IPv6 or the IPv4 version of the source address will result in the
-router trying to use the best IP address to contact the destination.
+for Cisco IOS XR, Extreme NetIron, BIRD and Quagga routers (use your own IP
+addresses). Omitting the IPv6 or the IPv4 version of the source address will
+result in the router trying to use the best IP address to contact the destination.
 
 After that you need to set the authentication information for the looking
 glass to be able to log into the router. For this you select a type of

--- a/docs/extreme_netiron.md
+++ b/docs/extreme_netiron.md
@@ -1,0 +1,78 @@
+# Looking Glass: Extreme NetIron configuration and tips.
+
+Extreme NetIron support has a few quirks one should be aware of.
+
+Looking Glass' SSH implementation requires single-command SSH support,
+which is unfortunately not available in this router.
+
+That means we must fall back to using Telnet to scrape the router CLI
+to obtain our output. Besides the obvious security implications of using
+Telnet, CLI scraping also means there's going to be some unwanted output
+surrounding your data.
+
+The best way to deal with the unwanted output is through Looking Glass'
+global filter support in the *config.php* file:
+
+```php
+$config['filters'][] = '/([^\x20-\x7E]|User|Please|Disable|telnet|^\s*$)/';
+```
+
+Please note that some of the unwanted output collected when a new telnet
+session is opened is not UTF-8 based, which breaks PHP's json_encode [1]
+function. The `[^\x20-\x7E]` portion of the aforementioned filter's
+regular-expression removes lines with such illegal characters so that
+the json_encode function can run without encountering trouble.
+
+
+## Security and user access
+
+Security by least privilege is a best practice, and therefore using a
+restricted user to execute the commands is advised.
+
+For Extreme NetIron routers, this is achieved through privilege exec
+level manipulation.
+
+Log in on your Extreme NetIron router with a read-write privileged user,
+and type in the following commands:
+
+```
+router#configure terminal
+router(config)#privilege exec level 5 skip-page-display
+router(config)#privilege exec level 5 traceroute
+router(config)#username lg privilege 5 password LG-USER-PASSWORD
+router(config)#end
+router#write memory
+```
+Note that the privilege level 5 used in this example refers to a READ-ONLY user:
+
+```
+router(config)#privilege exec level ?
+  DECIMAL   <0 READ-WRITE, 4 PORT-CONFIG, 5 READ-ONLY> Privilege level
+```
+
+## Debug
+
+Activate CLI command logging:
+
+```
+router#configure terminal
+router(config)#logging cli-command
+router(config)#end
+router#write memory
+```
+
+Test the Telnet connection from the server where the looking glass is installed.
+
+Display the resulting logs during your tests and match for lines relating to
+the LG-USER, for example, here is the logging for a ping query:
+
+```
+router#show logging | include lg
+Feb  7 17:32:09:I:Security: telnet terminated by lg from src IP $IP4-ADDR-OF-LG from USER EXEC mode
+Feb  7 17:32:08:I:CLI CMD: "ping $PARAMETER count 10 source $IP4-ADDR-SOURCE" by lg from telnet client $IP4-ADDR-OF-LG
+Feb  7 17:32:08:I:Security: telnet login by lg from src IP $IP4-ADDR-OF-LG to PRIVILEGED EXEC mode
+```
+
+## References
+
+  * [1] http://php.net/manual/en/function.json-encode.php

--- a/routers/extreme_netiron.php
+++ b/routers/extreme_netiron.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * Looking Glass - An easy to deploy Looking Glass
+ * Copyright (C) 2017-2018 Guillaume Mazoyer <gmazoyer@gravitons.in>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+require_once('router.php');
+require_once('includes/utils.php');
+
+final class ExtremeNetIron extends Router {
+  protected function build_ping($destination) {
+    $ping = null;
+
+    if (match_ipv4($destination) ||
+        (match_hostname($destination) && !$this->has_source_interface_id())) {
+      $ping = 'ping '.$destination. ' count 10';
+    } else if (match_ipv6($destination) ||
+        (match_hostname($destination) && !$this->has_source_interface_id())) {
+      $ping = 'ping ipv6 '.$destination. ' count 10';
+    } else if (match_hostname($destination)) {
+      $hostname = $destination;
+      $destination = hostname_to_ip_address($hostname, $this->config);
+
+      if (!$destination) {
+        throw new Exception('No record found for '.$hostname);
+      }
+
+      if (match_ipv6($destination)) {
+        $ping = 'ping ipv6 '.(isset($hostname) ? $hostname : $destination).
+          ' count 10';
+      } else if (match_ipv4($destination)) {
+        $ping = 'ping '.(isset($hostname) ? $hostname : $destination).
+          ' count 10';
+      } else {
+        throw new Exception('The parameter does not resolve to an IP address.');
+      }
+    } else {
+      throw new Exception('The parameter is not an IP address or a hostname.');
+    }
+
+    if (($ping != null) && $this->has_source_interface_id()) {
+      if (match_ipv6($destination) &&
+          ($this->get_source_interface_id('ipv6') != null)) {
+        $ping .= ' source '.$this->get_source_interface_id('ipv6');
+      } else if (match_ipv4($destination) &&
+          ($this->get_source_interface_id('ipv4') != null)) {
+        $ping .= ' source '.$this->get_source_interface_id('ipv4');
+      }
+    }
+
+    return $ping;
+  }
+
+  protected function build_traceroute($destination) {
+    $traceroute = null;
+
+    if (match_ipv4($destination) ||
+        (match_hostname($destination) && !$this->has_source_interface_id())) {
+      $traceroute = 'traceroute '.$destination;
+    } else if (match_ipv6($destination) ||
+        (match_hostname($destination) && !$this->has_source_interface_id())) {
+      $traceroute = 'traceroute ipv6 '.$destination;
+    } else if (match_hostname($destination)) {
+      $hostname = $destination;
+      $destination = hostname_to_ip_address($hostname);
+
+      if (!$destination) {
+        throw new Exception('No record found for '.$hostname);
+      }
+
+      if (match_ipv6($destination)) {
+        $traceroute = 'traceroute ipv6 '.(isset($hostname) ? $hostname : $destination);
+      } else if (match_ipv4($destination)) {
+        $traceroute = 'traceroute '.(isset($hostname) ? $hostname : $destination);
+      } else {
+        throw new Exception('The parameter does not resolve to an IP address.');
+      }
+    } else {
+      throw new Exception('The parameter is not an IP address or a hostname.');
+    }
+
+    if (($traceroute != null) && $this->has_source_interface_id()) {
+      if (match_ipv4($destination) &&
+          ($this->get_source_interface_id('ipv4') != null)) {
+        $traceroute .= ' source '.$this->get_source_interface_id('ipv4');
+      }
+    }
+
+    return $traceroute;
+  }
+
+  protected function build_commands($command, $parameter) {
+    $commands = array();
+
+    switch ($command) {
+      case 'bgp':
+        if (match_ipv6($parameter, false)) {
+          $commands[] = "skip-page-display\r\nshow ipv6 bgp routes ".$parameter;
+        } else if (match_ipv4($parameter, false)) {
+          $commands[] = "skip-page-display\r\nshow ip bgp routes ".$parameter;
+        } else {
+          throw new Exception('The parameter is not an IP address.');
+        }
+        break;
+
+      case 'as-path-regex':
+        if (match_aspath_regex($parameter)) {
+          if (!$this->config['disable_ipv6']) {
+            $commands[] = "skip-page-display\r\nshow ipv6 bgp routes regular-expression \"".$parameter.
+              '"';
+          }
+          if (!$this->config['disable_ipv4']) {
+            $commands[] = "skip-page-display\r\nshow ip bgp routes regular-expression \"".$parameter.
+              '"';
+          }
+        } else {
+          throw new Exception('The parameter is not an AS-Path regular expression.');
+        }
+        break;
+
+      case 'as':
+        if (match_as($parameter)) {
+          if (!$this->config['disable_ipv6']) {
+            $commands[] = "skip-page-display\r\nshow ipv6 bgp routes regular-expression \"_".$parameter.
+              '$"';
+          }
+          if (!$this->config['disable_ipv4']) {
+            $commands[] = "skip-page-display\r\nshow ip bgp routes regular-expression \"_".$parameter.
+              '$"';
+          }
+        } else {
+          throw new Exception('The parameter is not an AS number.');
+        }
+        break;
+
+      case 'ping':
+        try {
+          $commands[] = $this->build_ping($parameter);
+        } catch (Exception $e) {
+          throw $e;
+        }
+        break;
+
+      case 'traceroute':
+        try {
+          $commands[] = $this->build_traceroute($parameter);
+        } catch (Exception $e) {
+          throw $e;
+        }
+        break;
+
+      default:
+        throw new Exception('Command not supported.');
+    }
+
+    return $commands;
+  }
+}
+
+// End of extreme_netiron.php

--- a/routers/router.php
+++ b/routers/router.php
@@ -24,6 +24,7 @@ require_once('config.php');
 require_once('bird.php');
 require_once('cisco.php');
 require_once('cisco_iosxr.php');
+require_once('extreme_netiron.php');
 require_once('juniper.php');
 require_once('openbgpd.php');
 require_once('quagga.php');
@@ -173,6 +174,9 @@ abstract class Router {
       case 'cisco':
       case 'ios':
         return new Cisco($config, $router_config, $id, $requester);
+
+      case 'extreme_netiron':
+        return new ExtremeNetIron($config, $router_config, $id, $requester);
 
       case 'ios-xr':
       case 'iosxr':


### PR DESCRIPTION
This pull request adds initial support for Extreme/Brocade NetIron series routers.

There are some quirks which need to be dealt with for this platform, most notably, we have to enter `skip-page-display` before executing a `show ip bgp` or `show ipv6 bgp` style command so we can view output longer than 25 lines without having to press Space to view the next chunk of the output. I was able to take care of this problem through `routers/extreme_netiron.php`.

I have also modified some code to fix an eternal while loop in `auth/telnet.php`, which must be used because NetIron routers don't support the single-command SSH feature as implemented by Looking Glass. That means we must fall back to using Telnet to scrape the router CLI to obtain our output.

Besides the obvious security implications of using Telnet, CLI scraping also means there's going to be some unwanted output surrounding the data. I have found that the best way to deal with the unwanted output is through Looking Glass' global filter support in the *config.php* file:

```php
$config['filters'][] = '/([^\x20-\x7E]|User|Please|Disable|telnet|^\s*$)/';
```
Please note that some of the unwanted output collected when a new telnet session is opened is not UTF-8 based, which breaks PHP's json_encode [1] function. The `[^\x20-\x7E]` portion of the aforementioned filter's regular-expression removes lines with such illegal characters so that the json_encode function can run without encountering trouble. All of these quirks have of course been documented in `docs/extreme_netiron.md` for future reference.

[1] http://php.net/manual/en/function.json-encode.php