### PR TITLE
Configurable command form scaling (default to dynamic), support for disabling commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ For now this looking glass is quite simple. Here you have some features:
   * Tweakable interface (title, logo, footer, elements order)
   * Log all commands in a file
   * Customizable output with regular expressions
+  * Configurable list of allowed commands
 
 And here is a list of what this looking glass should be able to do in the
 future:
 
   * Support more routers
   * Support of other types of authentication
-  * Configurable list of allowed commands
 
 ## Configuration
 

--- a/auth/authentication.php
+++ b/auth/authentication.php
@@ -26,28 +26,28 @@ require_once('telnet.php');
 
 /**
  * This class needs to be extended by every class implementing an
- * authentication mecanism.
+ * authentication mechanism.
  *
- * It provides the basis to interact with an authentication mecanism.
+ * It provides the basis to interact with an authentication mechanism.
  *
- * When implementing an authentication mecanism, the subclass will need to
+ * When implementing an authentication mechanism, the subclass will need to
  * override several methods that define if the configuration is correct and
  * how to connect, disconnect and send a command to the host.
  */
 abstract class Authentication {
   /**
    * The configuration array containing information needed by the
-   * authentication mecanism.
+   * authentication mechanism.
    */
   protected $config;
 
   /**
-   * Build a new object to manipulate the authentication mecanism.
+   * Build a new object to manipulate the authentication mechanism.
    *
    * It will also check if the configuration is correct before doing the
    * instanciation.
    *
-   * @param array $config the configuration for the authentication mecanism.
+   * @param array $config the configuration for the authentication mechanism.
    */
   public function __construct($config) {
     $this->config = $config;
@@ -92,12 +92,12 @@ abstract class Authentication {
    * Method that decides which authentication method to instanciate based on a
    * given configuration.
    *
-   * Note: no instanciation of authentication mecanism class should be done
+   * Note: no instanciation of authentication mechanism class should be done
    * elsewhere than here.
    *
    * @param  array          $config the configuration for the authentication
-   *                                mecanism.
-   * @return Authentication the authentication mecanism to be used.
+   *                                mechanism.
+   * @return Authentication the authentication mechanism to be used.
    */
   public static final function instance($config) {
     switch ($config['auth']) {
@@ -109,7 +109,7 @@ abstract class Authentication {
         return new Telnet($config);
 
       default:
-        print('Unknown authentication mecanism "'.$config['auth'].'"."');
+        print('Unknown authentication mechanism "'.$config['auth'].'"."');
         return null;
     }
   }

--- a/docs/cisco_iosxr.md
+++ b/docs/cisco_iosxr.md
@@ -1,6 +1,6 @@
 # Looking Glass: Cisco IOS XR configuration and tips.
 
-Cisco IOS XR support is rather straightforward thanks to the tasks mecanism.
+Cisco IOS XR support is rather straightforward thanks to the tasks mechanism.
 
 ## Security and user access
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,7 +75,14 @@ $config['frontpage']['router_count'] = 5;
 ```
 Sets the number of routers to show on the front page before the list scrolls. If
 set to a positive integer, then that number of routers will be shown, otherwise
-the list will show all routers.
+the list will dynamically scale to show all routers (default is 5 routers).
+
+```php
+$config['frontpage']['command_count'] = 5;
+```
+Sets the number of commands to show on the front page before the list scrolls. If
+set to a positive integer, then that number of commands will be shown, otherwise
+the list will dynamically scale to show all commands (default is dynamic scaling).
 
 ### Contact
 
@@ -290,7 +297,7 @@ $config['doc']['ping']
 $config['doc']['traceroute']
 ```
 
-Each commands have a subset of options to configure the its title, its
+Each command has a subset of options to configure its title, its
 description summary and its detailed description. For example:
 
 ```php
@@ -299,4 +306,17 @@ $config['doc']['bgp']['description'] = '';
 $config['doc']['bgp']['parameter'] = '';
 ```
 
-See the defaults values for more details.
+See the default values for more details.
+
+## Disabling Commands
+
+The documentation configuration can also be used to disable commands by setting the
+title of the command to `null`. A disabled command will no longer show up in the user
+interface, and if an attacker tries to send a forged POST request with a disabled
+command to Looking Glass an error will be returned.
+
+For example, this piece of config would disable `as-path-regex` commands:
+
+```php
+$config['doc']['as-path-regex']['command'] = null;
+```

--- a/docs/juniper.md
+++ b/docs/juniper.md
@@ -39,7 +39,7 @@ user@router# set system login user <username> class looking-glass
 ```
 
 For security purpose, it is highly recommended to use an authentication
-mecanism based on SSH public keys. For that you can use one of the following
+mechanism based on SSH public keys. For that you can use one of the following
 commands:
 
 ```

--- a/docs/vyatta.md
+++ b/docs/vyatta.md
@@ -25,7 +25,7 @@ Firstly create a new user with the admin level privileges:
 set system login user <username> level admin
 ```
 
-For security purpose, it is highly recommended to use an authentication mecanism based on SSH public keys. For that you can use one of the following commands:
+For security purpose, it is highly recommended to use an authentication mechanism based on SSH public keys. For that you can use one of the following commands:
 
 ```
 [edit]

--- a/execute.php
+++ b/execute.php
@@ -50,6 +50,13 @@ if (isset($_POST['query']) && !empty($_POST['query']) &&
   $hostname = trim($_POST['routers']);
   $parameter = trim($_POST['parameter']);
 
+  // Check if query is disabled
+  if (!isset($config['doc'][$query]['command'])) {
+    $error = 'This query has been disabled in the configuration.';
+    print(json_encode(array('error' => $error)));
+    return;
+  }
+
   // Do the processing
   $router = Router::instance($hostname, $requester);
   $router_config = $router->get_config();

--- a/includes/config.defaults.php
+++ b/includes/config.defaults.php
@@ -71,7 +71,9 @@ $config = array(
     // Frontpage order you can use: routers, commands, parameter, buttons
     'order' => array('routers', 'commands', 'parameter', 'buttons'),
     // Number of routers to show on frontpage
-    'router_count' => 5
+    'router_count' => 5,
+    // Number of commands to show on frontpage (0 scales dynamically)
+    'command_count' => 0
   ),
 
   // Contact (both null for no contact)

--- a/index.php
+++ b/index.php
@@ -47,6 +47,18 @@ final class LookingGlass {
       return count($this->routers);
   }
 
+  private function command_count() {
+    if ($this->frontpage['command_count'] > 0)
+      return $this->frontpage['command_count'];
+    else
+      foreach (array_keys($this->doc) as $cmd) {
+        if (isset($this->doc[$cmd]['command'])) {
+          $command_count++;
+        }
+      }
+      return $command_count;
+  }
+
   private function render_routers() {
     print('<div class="form-group">');
     print('<label for="routers">Router to use</label>');
@@ -76,10 +88,12 @@ final class LookingGlass {
   private function render_commands() {
     print('<div class="form-group">');
     print('<label for="query">Command to issue</label>');
-    print('<select size="5" class="form-control" name="query" id="query">');
+    print('<select size="'.$this->command_count().'" class="form-control" name="query" id="query">');
     $selected = ' selected="selected"';
     foreach (array_keys($this->doc) as $cmd) {
-      print('<option value="'.$cmd.'"'.$selected.'>'.$this->doc[$cmd]['command'].'</option>');
+      if (isset($this->doc[$cmd]['command'])) {
+        print('<option value="'.$cmd.'"'.$selected.'>'.$this->doc[$cmd]['command'].'</option>');
+      }
       $selected = '';
     }
     print('</select>');


### PR DESCRIPTION
This pull request introduces a new configuration option to set the number of commands to be shown on the front page before the list scrolls. It defaults to dynamic scaling based on the amount of doc command entries that are not `null` (it was previously hard-coded to `size="5"`).

Secondly, commands can now be disabled in `config.php` by setting the doc command configuration entry to `null`. This hides the disabled command from `index.php`, and `execute.php` was hardened against forged POST requests containing such disabled commands. It will return a json encoded error when someone tries to use a hidden/disabled command.

For example, setting this line in `config.php` would disable the `as-path-regex` command:
```php
$config['doc']['as-path-regex']['command'] = null;
```
The documentation has been updated to reflect these two new features and disabling commands is listed as an implemented feature in `README.md`, rather than something that is to be implemented in the future.