### PR TITLE
Toggleable BGP detail output, fix some PHP warnings/notices, change OpenBGPD commands, update documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ execute some commands on routers. The output is sent back to the user.
 For now this looking glass is quite simple. Here you have some features:
 
   * Interface using Javascript and AJAX calls (needs a decent browser)
-  * Support of BIRD, Cisco (IOS and IOS-XR), Juniper, OpenBGPd, Quagga and
-    Vyatta/VyOS/EdgeOS routers
+  * Support of BIRD, Cisco (IOS and IOS-XR), Juniper, Extreme/Brocade NetIron,
+    OpenBGPd, Quagga, Vyatta/VyOS/EdgeOS and FRRouting routers
   * Support of Telnet and SSH connection to routers using password
     authentication and SSH keys
   * Configurable list of routers

--- a/auth/telnet.php
+++ b/auth/telnet.php
@@ -67,8 +67,10 @@ final class Telnet extends Authentication {
   }
 
   public function disconnect() {
-    fclose($this->connection);
-    $this->connection = null;
+    if ($this->connection) {
+      fclose($this->connection);
+      $this->connection = null;
+    }
   }
 }
 

--- a/config.php.example
+++ b/config.php.example
@@ -111,6 +111,8 @@ $config['routers']['router5']['source-interface-id']['ipv4'] = '192.168.1.1';
 $config['routers']['router5']['source-interface-id']['ipv6'] = '2001:db8::1';
 // The router description to be displayed in the router list
 $config['routers']['router5']['desc'] = 'Example\'s router 5';
+// Display BGP detail output for this router, defaults to false
+$config['routers']['router5']['bgp_detail'] = true;
 
 // If running on *BSD, disable '-A' which is non-existent
 $config['tools']['ping_options'] = '-c 5';

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,7 +121,7 @@ interact with it.
 $config['routers']['router1']['type'] = 'juniper';
 ```
 The router type can be Juniper, Cisco (IOS or IOS-XR), Extreme (NetIron), Quagga,
-BIRD, OpenBGPd or Vyatta/VyOS/EdgeOS. You can take a look at the specific
+BIRD, OpenBGPd, Vyatta/VyOS/EdgeOS, or FRRouting. You can take a look at the specific
 documentation for your router.
 Possible values are:
 
@@ -133,6 +133,7 @@ Possible values are:
   * quagga **or** zebra
   * openbgpd
   * edgeos **or** vyatta **or** vyos
+  * frr
 
 It is also highly recommended to specify a source interface ID to be used by
 the router when it will try to ping or traceroute a destination. This is done
@@ -170,6 +171,21 @@ $config['routers']['router1']['timeout'] = 30;
 ```
 Used to set the timeout (in seconds) for the connection to the router. The
 default value is 30 seconds.
+
+```php
+$config['routers']['router1']['bgp-detail'] = false;
+```
+If set to true, and supported by the router, display BGP detail output which
+contains information such as BGP communities, MED, origin, etc. The default
+value is false.
+
+This parameter can be toggled on Juniper, Extreme (NetIron), BIRD, and
+OpenBGPd routers.
+
+Cisco (IOS or IOS-XR), Quagga, Vyatta/VyOS/EdgeOS, and FRRouting routers do not
+support toggleable BGP detail output and will always display BGP detail output
+for `bgp` commands, and will never display BGP detail output for `as` and
+`as-path-regex` commands.
 
 #### Telnet
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,7 +173,7 @@ Used to set the timeout (in seconds) for the connection to the router. The
 default value is 30 seconds.
 
 ```php
-$config['routers']['router1']['bgp-detail'] = false;
+$config['routers']['router1']['bgp_detail'] = false;
 ```
 If set to true, and supported by the router, display BGP detail output which
 contains information such as BGP communities, MED, origin, etc. The default

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,21 +19,21 @@ execute some commands on routers. The output is sent back to the user.
 For now this looking glass is quite simple. Here you have some features:
 
   * Interface using Javascript and AJAX calls (needs a decent browser)
-  * Support of BIRD, Cisco (IOS and IOS-XR), Juniper, OpenBGPd, Quagga and
-    Vyatta/VyOS/EdgeOS routers
+  * Support of BIRD, Cisco (IOS and IOS-XR), Juniper, Extreme/Brocade NetIron,
+    OpenBGPd, Quagga, Vyatta/VyOS/EdgeOS and FRRouting routers
   * Support of Telnet and SSH connection to routers using password
     authentication and SSH keys
   * Configurable list of routers
   * Tweakable interface (title, logo, footer, elements order)
   * Log all commands in a file
   * Customizable output with regular expressions
+  * Configurable list of allowed commands
 
 And here is a list of what this looking glass should be able to do in the
 future:
 
   * Support more routers
   * Support of other types of authentication
-  * Configurable list of allowed commands
 
 ## Configuration
 

--- a/docs/our_users.md
+++ b/docs/our_users.md
@@ -8,3 +8,4 @@ small view of their networks.
   * [GLaNET](https://glanet.org/)
   * [SysEleven GmbH](https://www.syseleven.de/)
   * [BAEHOST](https://baehost.com/) - [Looking Glass](https://baehost.com/looking-glass/)
+  * [i3D.net](https://www.i3d.net/) - [Looking Glass](https://noc.i3d.net/lg/)

--- a/includes/config.defaults.php
+++ b/includes/config.defaults.php
@@ -28,7 +28,8 @@ function set_defaults_for_routers(&$parsed_config) {
   $router_defaults = array(
     'timeout' => 30,
     'disable_ipv6' => false,
-    'disable_ipv4' => false
+    'disable_ipv4' => false,
+    'bgp-detail' => false
   );
 
   // Loads defaults when key does not exist
@@ -142,12 +143,12 @@ $config = array(
     'as-path-regex' => array(
       'command' => 'show route as-path-regex AS_PATH_REGEX',
       'description' => 'Show the routes matching the given AS path regular expression.',
-      'parameter' => 'The parameter must be a valid AS path regular expression and must not contain any " characters (the input will be automatically quoted if needed).<br />Please note that these expressions can change depending on the router and its software.<br /><br />Here are some examples:<ul><li><strong>Juniper</strong> - ^AS1 AS2 .*$</li><li><strong>Cisco</strong> - ^AS1_</li><li><strong>BIRD</strong> - AS1 AS2 AS3 &hellip; ASZ</li></ul><br />You may find some help with the following link:<br /><ul><li><a href="http://www.juniper.net/techpubs/en_US/junos13.3/topics/reference/command-summary/show-route-aspath-regex.html" title="Juniper Documentation">Juniper Documentation</a></li><li><a href="http://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/26634-bgp-toc.html#asregexp" title="Cisco Documentation">Cisco Documentation</a></li><li><a href="http://bird.network.cz/?get_doc&f=bird-5.html" title="BIRD Documentation">BIRD Documentation</a> (search for bgpmask)</li></ul>'
+      'parameter' => 'The parameter must be a valid AS path regular expression and must not contain any " characters (the input will be automatically quoted if needed).<br />Please note that these expressions can change depending on the router and its software.<br />OpenBGPD does not support regular expressions, but will search for the submitted AS number anywhere in the AS path.<br /><br />Here are some examples:<ul><li><strong>Juniper</strong> - ^AS1 AS2 .*$</li><li><strong>Cisco</strong> - ^AS1_AS2_</li><li><strong>BIRD</strong> - AS1 AS2 AS3 &hellip; ASZ</li><li><strong>OpenBGPD</strong> - AS1</li></ul><br />You may find some help with the following link:<br /><ul><li><a href="http://www.juniper.net/techpubs/en_US/junos13.3/topics/reference/command-summary/show-route-aspath-regex.html" title="Juniper Documentation">Juniper Documentation</a></li><li><a href="http://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/26634-bgp-toc.html#asregexp" title="Cisco Documentation">Cisco Documentation</a></li><li><a href="http://bird.network.cz/?get_doc&f=bird-5.html" title="BIRD Documentation">BIRD Documentation</a> (search for bgpmask)</li></ul>'
     ),
     // Documentation for the 'as' query
     'as' => array(
-      'command' => 'show route AS',
-      'description' => 'Show the routes received from a given AS number.',
+      'command' => 'show route ^AS',
+      'description' => 'Show the routes received from a given neighboring AS number.',
       'parameter' => 'The parameter must be a valid 16-bit or 32-bit autonomous system number.<br />Be careful, 32-bit ASN are not handled by old routers or old router softwares.<br />Unless specified, private ASN will be considered as invalid.<br /><br />Example of valid argument:<br /><ul><li>15169</li><li>29467</li></ul>'
     ),
     // Documentation for the 'ping' query

--- a/includes/config.defaults.php
+++ b/includes/config.defaults.php
@@ -29,7 +29,7 @@ function set_defaults_for_routers(&$parsed_config) {
     'timeout' => 30,
     'disable_ipv6' => false,
     'disable_ipv4' => false,
-    'bgp-detail' => false
+    'bgp_detail' => false
   );
 
   // Loads defaults when key does not exist

--- a/index.php
+++ b/index.php
@@ -51,6 +51,7 @@ final class LookingGlass {
     if ($this->frontpage['command_count'] > 0)
       return $this->frontpage['command_count'];
     else
+      $command_count = 0;
       foreach (array_keys($this->doc) as $cmd) {
         if (isset($this->doc[$cmd]['command'])) {
           $command_count++;

--- a/routers/bird.php
+++ b/routers/bird.php
@@ -107,12 +107,18 @@ final class Bird extends Router {
     $birdc6 = 'birdc6';
     $birdc = 'birdc';
 
+    if ($this->config['bgp-detail']) {
+      $bgpdetail = ' all';
+    } else {
+      $bgpdetail = '';
+    }
+
     switch ($command) {
       case 'bgp':
         if (match_ipv6($parameter, false)) {
-          $commands[] = $birdc6.' \'show route for '.$parameter.'\'';
+          $commands[] = $birdc6.' \'show route for '.$parameter.$bgpdetail.'\'';
         } else if (match_ipv4($parameter, false)) {
-          $commands[] = $birdc.' \'show route for '.$parameter.'\'';
+          $commands[] = $birdc.' \'show route for '.$parameter.$bgpdetail.'\'';
         } else {
           throw new Exception('The parameter is not an IP address.');
         }
@@ -122,11 +128,11 @@ final class Bird extends Router {
         if (match_aspath_regex($parameter)) {
           if (!$this->config['disable_ipv6']) {
             $commands[] = $birdc6.' \'show route where bgp_path ~ [= '.
-              $parameter.' =]\'';
+              $parameter.' =]'.$bgpdetail.'\'';
           }
           if (!$this->config['disable_ipv4']) {
             $commands[] = $birdc.' \'show route where bgp_path ~ [= '.
-              $parameter.' =]\'';
+              $parameter.' =]'.$bgpdetail.'\'';
           }
         } else {
           throw new Exception('The parameter is not an AS-Path regular expression.');
@@ -137,11 +143,11 @@ final class Bird extends Router {
         if (match_as($parameter)) {
           if (!$this->config['disable_ipv6']) {
             $commands[] = $birdc6.' \'show route where bgp_path ~ [= '.
-              $parameter.' =]\'';
+              $parameter.' =]'.$bgpdetail.'\'';
           }
           if (!$this->config['disable_ipv4']) {
             $commands[] = $birdc.' \'show route where bgp_path ~ [= '.
-              $parameter.' =]\'';
+              $parameter.' =]'.$bgpdetail.'\'';
           }
         } else {
           throw new Exception('The parameter is not an AS number.');

--- a/routers/bird.php
+++ b/routers/bird.php
@@ -107,7 +107,7 @@ final class Bird extends Router {
     $birdc6 = 'birdc6';
     $birdc = 'birdc';
 
-    if ($this->config['bgp-detail']) {
+    if ($this->config['bgp_detail']) {
       $bgpdetail = ' all';
     } else {
       $bgpdetail = '';

--- a/routers/extreme_netiron.php
+++ b/routers/extreme_netiron.php
@@ -107,12 +107,18 @@ final class ExtremeNetIron extends Router {
   protected function build_commands($command, $parameter) {
     $commands = array();
 
+    if ($this->config['bgp-detail']) {
+      $bgpdetail = 'detail ';
+    } else {
+      $bgpdetail = '';
+    }
+
     switch ($command) {
       case 'bgp':
         if (match_ipv6($parameter, false)) {
-          $commands[] = "skip-page-display\r\nshow ipv6 bgp routes ".$parameter;
+          $commands[] = "skip-page-display\r\nshow ipv6 bgp routes ".$bgpdetail.$parameter;
         } else if (match_ipv4($parameter, false)) {
-          $commands[] = "skip-page-display\r\nshow ip bgp routes ".$parameter;
+          $commands[] = "skip-page-display\r\nshow ip bgp routes ".$bgpdetail.$parameter;
         } else {
           throw new Exception('The parameter is not an IP address.');
         }
@@ -121,11 +127,11 @@ final class ExtremeNetIron extends Router {
       case 'as-path-regex':
         if (match_aspath_regex($parameter)) {
           if (!$this->config['disable_ipv6']) {
-            $commands[] = "skip-page-display\r\nshow ipv6 bgp routes regular-expression \"".$parameter.
+            $commands[] = "skip-page-display\r\nshow ipv6 bgp routes ".$bgpdetail."regular-expression \"".$parameter.
               '"';
           }
           if (!$this->config['disable_ipv4']) {
-            $commands[] = "skip-page-display\r\nshow ip bgp routes regular-expression \"".$parameter.
+            $commands[] = "skip-page-display\r\nshow ip bgp routes ".$bgpdetail."regular-expression \"".$parameter.
               '"';
           }
         } else {
@@ -136,12 +142,12 @@ final class ExtremeNetIron extends Router {
       case 'as':
         if (match_as($parameter)) {
           if (!$this->config['disable_ipv6']) {
-            $commands[] = "skip-page-display\r\nshow ipv6 bgp routes regular-expression \"_".$parameter.
-              '$"';
+            $commands[] = "skip-page-display\r\nshow ipv6 bgp routes ".$bgpdetail."regular-expression \"^".$parameter.
+              '_"';
           }
           if (!$this->config['disable_ipv4']) {
-            $commands[] = "skip-page-display\r\nshow ip bgp routes regular-expression \"_".$parameter.
-              '$"';
+            $commands[] = "skip-page-display\r\nshow ip bgp routes ".$bgpdetail."regular-expression \"^".$parameter.
+              '_"';
           }
         } else {
           throw new Exception('The parameter is not an AS number.');

--- a/routers/extreme_netiron.php
+++ b/routers/extreme_netiron.php
@@ -107,7 +107,7 @@ final class ExtremeNetIron extends Router {
   protected function build_commands($command, $parameter) {
     $commands = array();
 
-    if ($this->config['bgp-detail']) {
+    if ($this->config['bgp_detail']) {
       $bgpdetail = 'detail ';
     } else {
       $bgpdetail = '';

--- a/routers/juniper.php
+++ b/routers/juniper.php
@@ -61,7 +61,7 @@ final class Juniper extends Router {
   protected function build_commands($command, $parameter) {
     $commands = array();
 
-    if ($this->config['bgp-detail']) {
+    if ($this->config['bgp_detail']) {
       $bgpdetail = ' detail';
     } else {
       $bgpdetail = '';

--- a/routers/juniper.php
+++ b/routers/juniper.php
@@ -61,14 +61,20 @@ final class Juniper extends Router {
   protected function build_commands($command, $parameter) {
     $commands = array();
 
+    if ($this->config['bgp-detail']) {
+      $bgpdetail = ' detail';
+    } else {
+      $bgpdetail = '';
+    }
+
     switch ($command) {
       case 'bgp':
         if (match_ipv6($parameter, false)) {
           $commands[] = 'show route '.$parameter.
-            ' protocol bgp table inet6.0 active-path';
+            ' protocol bgp table inet6.0 active-path'.$bgpdetail;
         } else if (match_ipv4($parameter, false)) {
           $commands[] = 'show route '.$parameter.
-            ' protocol bgp table inet.0 active-path';
+            ' protocol bgp table inet.0 active-path'.$bgpdetail;
         } else {
           throw new Exception('The parameter is not an IP address.');
         }
@@ -78,11 +84,11 @@ final class Juniper extends Router {
         if (match_aspath_regex($parameter)) {
           if (!$this->config['disable_ipv6']) {
             $commands[] = 'show route aspath-regex "'.$parameter.
-              '" protocol bgp table inet6.0';
+              '" protocol bgp table inet6.0'.$bgpdetail;
           }
           if (!$this->config['disable_ipv4']) {
             $commands[] = 'show route aspath-regex "'.$parameter.
-              '" protocol bgp table inet.0';
+              '" protocol bgp table inet.0'.$bgpdetail;
           }
         } else {
           throw new Exception('The parameter is not an AS-Path regular expression.');
@@ -93,11 +99,11 @@ final class Juniper extends Router {
         if (match_as($parameter)) {
           if (!$this->config['disable_ipv6']) {
             $commands[] = 'show route aspath-regex "^'.$parameter.
-              ' .*" protocol bgp table inet6.0';
+              ' .*" protocol bgp table inet6.0'.$bgpdetail;
           }
           if (!$this->config['disable_ipv4']) {
             $commands[] = 'show route aspath-regex "^'.$parameter.
-              ' .*" protocol bgp table inet.0';
+              ' .*" protocol bgp table inet.0'.$bgpdetail;
           }
         } else {
           throw new Exception('The parameter is not an AS number.');

--- a/routers/openbgpd.php
+++ b/routers/openbgpd.php
@@ -107,18 +107,32 @@ final class OpenBGPd extends Router {
 
     $bgpctl = 'bgpctl ';
 
+    if ($this->config['bgp-detail']) {
+      $bgpdetail = ' detail';
+    } else {
+      $bgpdetail = '';
+    }
+
     switch ($command) {
       case 'bgp':
         if (match_ipv6($parameter, false) or match_ipv4($parameter, false)) {
-          $commands[] = $bgpctl.'show ip bgp '.$parameter;
+          $commands[] = $bgpctl.'show rib'.$bgpdetail.' '.$parameter;
         } else {
           throw new Exception('The parameter is not an IP address.');
         }
         break;
 
+      case 'as-path-regex':
+        if (match_as($parameter)) {
+          $commands[] = $bgpctl.'show rib'.$bgpdetail.' as '.$parameter;
+        } else {
+          throw new Exception('The parameter is not an AS number - OpenBGPD does not support AS-Path regular expressions.');
+        }
+        break;
+
       case 'as':
         if (match_as($parameter)) {
-          $commands[] = $bgpctl.'show ip bgp as '.$parameter;
+          $commands[] = $bgpctl.'show rib'.$bgpdetail.' peer-as '.$parameter;
         } else {
           throw new Exception('The parameter is not an AS number.');
         }

--- a/routers/openbgpd.php
+++ b/routers/openbgpd.php
@@ -107,7 +107,7 @@ final class OpenBGPd extends Router {
 
     $bgpctl = 'bgpctl ';
 
-    if ($this->config['bgp-detail']) {
+    if ($this->config['bgp_detail']) {
       $bgpdetail = ' detail';
     } else {
       $bgpdetail = '';

--- a/routers/router.php
+++ b/routers/router.php
@@ -55,8 +55,8 @@ abstract class Router {
     if (!isset($this->config['disable_ipv4'])) {
       $this->config['disable_ipv4'] = false;
     }
-    if (!isset($this->config['bgp-detail'])) {
-      $this->config['bgp-detail'] = false;
+    if (!isset($this->config['bgp_detail'])) {
+      $this->config['bgp_detail'] = false;
     }
   }
 

--- a/routers/router.php
+++ b/routers/router.php
@@ -55,6 +55,9 @@ abstract class Router {
     if (!isset($this->config['disable_ipv4'])) {
       $this->config['disable_ipv4'] = false;
     }
+    if (!isset($this->config['bgp-detail'])) {
+      $this->config['bgp-detail'] = false;
+    }
   }
 
   private function sanitize_output($output) {


### PR DESCRIPTION
This pull request fixes some PHP warnings/notices in `telnet.php` + `index.php` and introduces a new configuration option + documentation for toggleable BGP detail output, which may contain information such as BGP communities, MED, origin, etc. Toggleable BGP detail output is supported on Juniper, Extreme (NetIron), BIRD, and OpenBGPD routers. The default value is false.

Cisco (IOS or IOS-XR), Quagga, Vyatta/VyOS/EdgeOS, and FRRouting routers do not support toggleable BGP detail output and will always display BGP detail output for `bgp` commands, and will never display BGP detail output for `as` and `as-path-regex` commands. The BGP detail toggle is therefore ignored on these platforms.

For example, setting this line in `config.php` would enable BGP detail output for `router1`:

```php
$config['routers']['router1']['bgp_detail'] = true;
```

The `as` command for Extreme/Brocade NetIron and OpenBGPD routers was updated to match the behaviour of the other routers e.g. "begins with" rather than "ends with" and "anywhere in the AS_PATH" respectively, and I've taken the liberty to clarify the default web-interface documentation to indicate that the `as` command shows routes from the given neighboring AS.

OpenBGPD has been changed to use `show rib` rather than `show ip bgp` style commands and now also supports a limited version of the `as-path-regex` command, per OpenBGPD's [manual](https://man.openbsd.org/bgpctl#show_rib): _"Show all entries with **as** anywhere in the AS path."_. This exception to the rule has also been added to the default web-interface documentation and Looking Glass will throw an explanatory error if the user tries to enter anything but an AS number in the parameter field when using `as-path-regex` commands on OpenBGPD routers.

Finally, I have added basic documentation mentions for FRRouting support since it was missing completely, and added my employer i3D.net as one of the users of this project - our Looking Glass deployment will go live in the near future!

PS: special thanks to job, Cybertinus, rve-- and SwedeMike on IRCNet for helping me with the CLI command syntax and BGP output of router platforms which I personally didn't have immediate access to.