### PR TITLE
Fix for example and openbgpd.php to make them usable

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -91,7 +91,8 @@ $config['routers']['router4']['auth'] = 'ssh-password';
 // The router type (can only be openbgpd)
 $config['routers']['router4']['type'] = 'openbgpd';
 // The router source address to be used
-$config['routers']['router4']['source-interface-id'] = '192.168.1.1';
+$config['routers']['router4']['source-interface-id']['ipv4'] = '192.168.1.1';
+$config['routers']['router4']['source-interface-id']['ipv6'] = '2001:db8::1';
 // The router description to be displayed in the router list
 $config['routers']['router4']['desc'] = 'OpenBGPd Router';
 

--- a/routers/openbgpd.php
+++ b/routers/openbgpd.php
@@ -37,11 +37,9 @@ final class OpenBGPd extends Router {
     }
 
     if (match_ipv6($destination)) {
-      $ping = 'ping6 '.$this->global_config['tools']['ping_options'].' '.
-        (isset($hostname) ? $hostname : $destination);
+      $ping = 'ping6 '.$this->global_config['tools']['ping_options'];
     } else if (match_ipv4($destination)) {
-      $ping = 'ping '.$this->global_config['tools']['ping_options'].' '.
-        (isset($hostname) ? $hostname : $destination);
+      $ping = 'ping '.$this->global_config['tools']['ping_options'];
     } else {
       throw new Exception('The parameter does not resolve to an IP address.');
     }
@@ -50,11 +48,13 @@ final class OpenBGPd extends Router {
       if (match_ipv6($destination) &&
           ($this->get_source_interface_id('ipv6') != null)) {
         $ping .= ' '.$this->global_config['tools']['ping_source_option'].' '.
-          $this->get_source_interface_id('ipv6');
+          $this->get_source_interface_id('ipv6').' '.
+        (isset($hostname) ? $hostname : $destination);
       } else if (match_ipv4($destination) &&
           ($this->get_source_interface_id('ipv4') != null)) {
         $ping .= ' '.$this->global_config['tools']['ping_source_option'].' '.
-          $this->get_source_interface_id('ipv4');
+          $this->get_source_interface_id('ipv4').' '.
+        (isset($hostname) ? $hostname : $destination);
       }
     }
 
@@ -75,12 +75,10 @@ final class OpenBGPd extends Router {
 
     if (match_ipv6($destination)) {
       $traceroute = $this->global_config['tools']['traceroute6'].' '.
-        $this->global_config['tools']['traceroute_options'].' '.
-        (isset($hostname) ? $hostname : $destination);
+        $this->global_config['tools']['traceroute_options'];
     } else if (match_ipv4($destination)) {
       $traceroute = $this->global_config['tools']['traceroute4'].' '.
-        $this->global_config['tools']['traceroute_options'].' '.
-        (isset($hostname) ? $hostname : $destination);
+        $this->global_config['tools']['traceroute_options'];
     } else {
       throw new Exception('The parameter does not resolve to an IP address.');
     }
@@ -90,12 +88,14 @@ final class OpenBGPd extends Router {
           ($this->get_source_interface_id('ipv6') != null)) {
         $traceroute .= ' '.
           $this->global_config['tools']['traceroute_source_option'].' '.
-          $this->get_source_interface_id('ipv6');
+          $this->get_source_interface_id('ipv6').' '.
+          (isset($hostname) ? $hostname : $destination);
       } else if (match_ipv4($destination) &&
           ($this->get_source_interface_id('ipv4') != null)) {
         $traceroute .= ' '.
           $this->global_config['tools']['traceroute_source_option'].' '.
-          $this->get_source_interface_id('ipv4');
+          $this->get_source_interface_id('ipv4').' '. 
+          (isset($hostname) ? $hostname : $destination);
       }
     }
 


### PR DESCRIPTION
1) Changed order for IP address argument and source interface for ping/ping6 + traceroute/traceroute6 commands to be valid in OpenBSD. 

2) Corrected examples to be valid for both IPv4 and IPv6 addresses for source interface (same as for other example router). Default order with IP address in the middle of other arguments is not valid. 

All changes tested on OpenBSD 6.1 and OpenBSD 6.3 releases.