### PR TITLE
[Mikrotik/ROS] Fixed command syntax for matching routes having originated from a specific AS

### DIFF
--- a/docs/mikrotik.md
+++ b/docs/mikrotik.md
@@ -2,27 +2,23 @@
 
 ## Security and user access
 
-As security by least privilege is quite efficient, using a restricted user to
-execute the commands is advised.
-
-A super-user access is not necessary, a read-only user is not sufficient
-though. The operator class would be good enough. It is better to define a new
-class with access to specific commands to restrict the looking glass user to
-what it actually needs (no more, no less).
+As security by least privilege is quite efficient, using a restricted read-only
+user to execute the commands is advised.
 
 ## Configuration: User Class
 
-Log in your ROS router and get in CLI mode if necessary, type the
-following commands to create a new class for looking glass users:
+Log in your ROS router via Terminal or SSH mode and type the
+following command to create a new read-only user:
 
 ```
-[edit]
 [admin@mikrotik] > /user add name=ro_user comment="read-only user for looking-glass" address=x.x.x.x password=xxx
 ```
 
 Where `address=x.x.x.x` is the source address of your looking-glass 
 installation and `password=xxx` is your desired password for the
 newly created read-only user.
+
+It is strongly advised to create matching firewall rules for SSH.
 
 ## Debug
 

--- a/docs/mikrotik.md
+++ b/docs/mikrotik.md
@@ -5,9 +5,9 @@
 As security by least privilege is quite efficient, using a restricted read-only
 user to execute the commands is advised.
 
-## Configuration: User Class
+## Configuration: Read-only user
 
-Log in your ROS router via Terminal or SSH mode and type the
+Log in your ROS router via Terminal or SSH and type the
 following command to create a new read-only user:
 
 ```
@@ -18,7 +18,7 @@ Where `address=x.x.x.x` is the source address of your looking-glass
 installation and `password=xxx` is your desired password for the
 newly created read-only user.
 
-It is strongly advised to create matching firewall rules for SSH.
+It is strongly recommended to create matching firewall rules for SSH/Telnet.
 
 ## Debug
 

--- a/docs/mikrotik.md
+++ b/docs/mikrotik.md
@@ -11,7 +11,7 @@ Log in your ROS router via Terminal or SSH mode and type the
 following command to create a new read-only user:
 
 ```
-[admin@mikrotik] > /user add name=ro_user comment="read-only user for looking-glass" address=x.x.x.x password=xxx
+[admin@mikrotik] > /user add name=ro_user group=read comment="read-only user" address=x.x.x.x password=xxx
 ```
 
 Where `address=x.x.x.x` is the source address of your looking-glass 

--- a/routers/mikrotik.php
+++ b/routers/mikrotik.php
@@ -95,10 +95,10 @@ final class Mikrotik extends Router {
       case 'as':
         if (match_as($parameter)) {
           if (!$this->config['disable_ipv6']) {
-            $commands[] = 'ipv6 route print '.$bgpdetail.' where bgp-as-path="'.$parameter.'"';
+            $commands[] = 'ipv6 route print '.$bgpdetail.' where bgp-as-path~"'.$parameter.'\$"';
           }
           if (!$this->config['disable_ipv4']) {
-            $commands[] = 'ip route print '.$bgpdetail.' where bgp-as-path="'.$parameter.'"';
+            $commands[] = 'ip route print '.$bgpdetail.' where bgp-as-path~"'.$parameter.'\$"';
           }
         } else {
           throw new Exception('The parameter is not an AS number.');


### PR DESCRIPTION
- This PR fixes the command syntax for matching routes having originated from a specific AS
- The readme for Mikrotik/ROS has been cleaned-up and enhanced