### PR TITLE
Fix erros tracerouting domain that resolves to multiple ipv4

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -284,7 +284,7 @@ function hostname_to_ip_address($hostname, $config = null) {
 
     foreach ($dns_record as $record) {
       if ($record['type'] == 'A') {
-        return $record['ipv4'];
+        return $record['ip'];
       }
     }
 


### PR DESCRIPTION
When tracerouting domain like yahoo.com which returns several ipv4, there is a error thrown:
`Error! No record found for yahoo.com`.  This is a simple typo in includes/utils.php .