### PR TITLE
Add option to use sudo or doas on OpenBSD

### DIFF
--- a/routers/openbgpd.php
+++ b/routers/openbgpd.php
@@ -105,7 +105,13 @@ final class OpenBGPd extends Router {
   protected function build_commands($command, $parameter) {
     $commands = array();
 
-    $bgpctl = 'bgpctl ';
+    if ($this->config['bgp_sudo'] == 1) {
+        $bgpctl = 'sudo bgpctl ';
+    } elseif ($this->config['bgp_sudo'] == 2) {
+        $bgpctl = 'doas bgpctl ';
+    } else {
+        $bgpctl = 'bgpctl ';
+    }
 
     if ($this->config['bgp_detail']) {
       $bgpdetail = ' detail';


### PR DESCRIPTION
It include a bgp_sudo option on a openbsd router to allow to use sudo or doas to execute the bgpctl commands. 

This is nice to have to allow access only at the "show" sub-command of bgpctl and no access to the destructive command (neighbor down for example).