### PR TITLE
Enable inline output filtering

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -24,6 +24,9 @@ $config['frontpage']['disclaimer'] = 'This is a disclaimer!';
 // Things to remove from the output (PHP compatible regex)
 $config['filters']['output'][] = '/(client1|client2)/';
 $config['filters']['output'][] = '/^NotToShow/';
+// Matched patterns can also replaced inline
+$config['filters']['output'][] = ['/replacethis/', 'withthis'];
+
 // If telnet is used in combination with extreme_netiron, uncomment the following filter
 //$config['filters']['output'][] = '/([^\x20-\x7E]|User|Please|Disable|telnet|^\s*$)/';
 

--- a/routers/router.php
+++ b/routers/router.php
@@ -73,17 +73,20 @@ abstract class Router {
       $valid = true;
 
       foreach ($this->global_config['filters']['output'] as $filter) {
-        // Line has been marked as invalid
-        // Or filtered based on the configuration
-        if (!$valid || (preg_match($filter, $line) === 1)) {
-          $valid = false;
-          break;
+        if (gettype($filter) == gettype(array())) {
+          $line = preg_replace($filter[0], $filter[1], $line);
+        } else {
+          // Line has been marked as invalid
+          // Or filtered based on the configuration
+          if (!$valid || (preg_match($filter, $line) === 1)) {
+            $valid = false;
+            break;
+          }
         }
       }
-
-     if ($valid) {
-        // The line is valid, print it
-        $filtered .= $line."\n";
+      if ($valid) {
+          // The line is valid, print it
+          $filtered .= $line."\n";
       }
     }
 

--- a/routers/router.php
+++ b/routers/router.php
@@ -85,8 +85,8 @@ abstract class Router {
         }
       }
       if ($valid) {
-          // The line is valid, print it
-          $filtered .= $line."\n";
+        // The line is valid, print it
+        $filtered .= $line."\n";
       }
     }
 


### PR DESCRIPTION
Currently, filtering works by discarding all lines matching at least one filter pattern.
This PR adds functionality to replace a pattern inline e.g. without discarding the whole line. This can be used to redact certain parts of the output while still maintaining the overall structure.

In the config this intent is expressed by defining a filter as an array of two elements where the first array item describes the regex to be matched in the output and the second array item describes the string the previously matched pattern is to be replaced with.  