### PR TITLE
Add config to provide additional html head elements 

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,11 @@ Sets the number of commands to show on the front page before the list scrolls. I
 set to a positive integer, then that number of commands will be shown, otherwise
 the list will dynamically scale to show all commands (default is dynamic scaling).
 
+```php
+$config['frontpage']['additional_html_header'] = '<link rel="icon" href="/static/images/cropped-32x32.png" sizes="32x32" /><link rel="icon" href="/static/images/cropped-192x192.png" sizes="192x192" /><link rel="apple-touch-icon-precomposed" href="/static/images/cropped-180x180.png" /><meta name="msapplication-TileImage" content="/static/images/cropped-270x270.png" />';
+```
+Sets additional HTML-Elements between <head> and </head> of index.php
+
 ### Contact
 
 ```php

--- a/index.php
+++ b/index.php
@@ -285,6 +285,9 @@ final class LookingGlass {
     print('<meta name="viewport" content="width=device-width, initial-scale=1" />');
     print('<meta name="keywords" content="Looking Glass, LG, BGP, prefix-list, AS-path, ASN, traceroute, ping, IPv4, IPv6, Cisco, Juniper, Internet" />');
     print('<meta name="description" content="'.$this->frontpage['title'].'" />');
+    if($this->frontpage['additional_html_header']) {
+      print($this->frontpage['additional_html_header']);
+    }
     print('<title>'.htmlentities($this->frontpage['title']).'</title>');
     print('<link href="libs/bootstrap-4.3.1/css/bootstrap.min.css" rel="stylesheet" />');
     print('<link href="'.$this->frontpage['css'].'" rel="stylesheet" />');


### PR DESCRIPTION
As described in issue #92 I added minor code-change (and documented it) to be able to properly set a favicon (or other elements like additional meta-tags etc) to <head> section of index.php