### PR TITLE
Fix FRR commands and no longer inherit Quagga

### DIFF
--- a/routers/frr.php
+++ b/routers/frr.php
@@ -29,10 +29,8 @@ class FRR extends UNIX {
   protected function build_bgp($parameter) {
     $cmd = new CommandBuilder();
     // vytsh commands need to be quoted
-    $cmd->add(self::$wrapper, '"', 'show');
-	
-	$cmd->add('bgp');
-
+    $cmd->add(self::$wrapper, '"', 'show bgp');
+	  
     if (match_ipv6($parameter, false)) {
       $cmd->add('ipv6');
     }
@@ -65,4 +63,5 @@ class FRR extends UNIX {
     return $this->build_aspath_regexp($parameter);
   }
 }
+
 // End of frr.php

--- a/routers/frr.php
+++ b/routers/frr.php
@@ -23,7 +23,7 @@ require_once('unix.php');
 require_once('includes/command_builder.php');
 require_once('includes/utils.php');
 
-class FRR extends UNIX {
+final class FRR extends UNIX {
   protected static $wrapper = 'vtysh -c';
 
   protected function build_bgp($parameter) {

--- a/routers/frr.php
+++ b/routers/frr.php
@@ -54,7 +54,7 @@ class FRR extends UNIX {
       $commands[] = (clone $cmd)->add('bgp ipv6 regexp', $parameter, '"');
     }
     if (!$this->config['disable_ipv4']) {
-      $commands[] = (clone $cmd)->add('bgp ip regexp', $parameter, '"');
+      $commands[] = (clone $cmd)->add('bgp ipv4 regexp', $parameter, '"');
     }
 
     return $commands;


### PR DESCRIPTION
FRR has a different order for some commands vs quagga.

show bgp ipv4 unicast 127.0.0.1 vs  show ipv4 bgp unicast 127.0.0.1
and 
show bgp ip regexp vs show ipv4 regexp

Removed require_once of quagga, updated commands.

<!--
  Thank you for your interest in contributing to Looking Glass.

  Please note that our contribution policy requires that a feature request or
  bug report be opened for approval prior to filing a pull request.

  Please indicate the feature request or bug report below. If your pull
  request does not reference an accepted bug report or feature request, it will
  be marked as invalid and closed.
-->
### Fixes:
#110

Current inherited quagga commands do not work on FRR.

Updated FRR.php to no longer inherit Quagga and fixed command order.
