### PR TITLE
Prefill parameter field with user's IP

### DIFF
--- a/execute.php
+++ b/execute.php
@@ -25,15 +25,7 @@ require_once('routers/router.php');
 require_once('includes/utils.php');
 
 // From where the user *really* comes from.
-if ($config['misc']['enable_http_x_forwarded_for'] === true && isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-  // The user can pass several proxy's, which each one will add its own IP address,
-  //  so we like to take only the first IP address
-  $ips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
-  $ip = trim($ips[0]);
-  $requester = is_valid_ip_address($ip) ? $ip : $_SERVER['REMOTE_ADDR']; // as a fallback we use the REMOTE_ADDR
-} else {
-  $requester = $_SERVER['REMOTE_ADDR'];
-}
+$requester = get_requester_ip();
 
 // Obvious spam
 if (!isset($_POST['dontlook']) || !empty($_POST['dontlook'])) {

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -363,4 +363,21 @@ function quote($string) {
   return sprintf('"%s"', $string);
 }
 
+/**
+ * Return IP address of the requester.
+ */
+function get_requester_ip() {
+  global $config;
+  if ($config['misc']['enable_http_x_forwarded_for'] === true && isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+    // The user can pass several proxy's, which each one will add its own IP address,
+    //  so we like to take only the first IP address
+    $ips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
+    $ip = trim($ips[0]);
+    $requester = is_valid_ip_address($ip) ? $ip : $_SERVER['REMOTE_ADDR']; // as a fallback we use the REMOTE_ADDR
+  } else {
+    $requester = $_SERVER['REMOTE_ADDR'];
+  }
+  return $requester;
+}
+
 // End of utils.php

--- a/index.php
+++ b/index.php
@@ -104,10 +104,15 @@ final class LookingGlass {
   }
 
   private function render_parameter() {
+    if ($this->frontpage['show_visitor_ip']) {
+      $requester = htmlentities(get_requester_ip());
+    } else {
+      $requester = "";
+    }
     print('<div class="form-group">');
     print('<label for="input-param">Parameter</label>');
     print('<div class="input-group">');
-    print('<input class="form-control" name="parameter" id="input-param" autofocus />');
+    print('<input class="form-control" name="parameter" id="input-param" autofocus value="'.$requester.'" />');
     print('<div class="input-group-append">');
     print('<button type="button" class="btn btn-info" data-toggle="modal" data-target="#help">');
     print('<i class="fas fa-question-circle"></i> Help');
@@ -203,16 +208,7 @@ final class LookingGlass {
     print('<p class="text-center">');
 
     if ($this->frontpage['show_visitor_ip']) {
-      if ($this->misc['enable_http_x_forwarded_for'] === true && isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        // The user can pass several proxy's, which each one will add its own IP address,
-        //  so we like to take only the first IP address
-        $ips = explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']);
-        $ip = trim($ips[0]);
-        $requester = is_valid_ip_address($ip) ? $ip : $_SERVER['REMOTE_ADDR']; // as a fallback we use the REMOTE_ADDR
-        printf('Your IP address: %s<br>', htmlentities($requester));
-      } else {
-        printf('Your IP address: %s<br>', htmlentities($_SERVER['REMOTE_ADDR']));
-      }
+      printf('Your IP address: %s<br>', htmlentities(get_requester_ip()));
     }
 
     if ($this->frontpage['disclaimer']) {


### PR DESCRIPTION
### Fixes:  #146

Prefills user's IP address in the parameter field if the configuration asks to display it on the frontpage. This also refactors a bit how we get this IP address as it is used in several places.