### PR TITLE
Fix antispam honeypot precedence bug (and/or vs && ||)

### DIFF
--- a/includes/antispam.php
+++ b/includes/antispam.php
@@ -123,8 +123,8 @@ class AntiSpam {
     $query->execute();
     $result = $query->fetch();
 
-    $in_period = !empty($result) and time() < $result['no_query_period'];
-    $obvious_spam = !isset($_POST['dontlook']) or !empty($_POST['dontlook']);
+    $in_period = (!empty($result) && time() < $result['no_query_period']);
+    $obvious_spam = (isset($_POST['dontlook']) && !empty($_POST['dontlook']));
 
     $degree = $in_period ? $result['degree'] + 1 : ($obvious_spam ? 512 : 1);
     $no_query_period = $this->no_query_period($degree);


### PR DESCRIPTION
## Problem

In `AntiSpam::check_user()` ([`includes/antispam.php:126-127`](https://github.com/gmazoyer/looking-glass/blob/main/includes/antispam.php#L126-L127)) two flag assignments use PHP's low-precedence `and`/`or` operators. Those bind *less* tightly than `=`, so:

```php
$in_period = !empty($result) and time() < $result['no_query_period'];
```

evaluates as

```php
($in_period = !empty($result)) and (time() < $result['no_query_period']);
```

— the right-hand expression is computed but **discarded**. `$in_period` ends up being just `!empty($result)`, so the `no_query_period` timestamp check is silently dropped and stale rows keep returning "still in period" past their expiry (until `clean_no_query_periods()` evicts them on the next run).

The second line:

```php
$obvious_spam = !isset($_POST['dontlook']) or !empty($_POST['dontlook']);
```

becomes `$obvious_spam = !isset($_POST['dontlook'])`. The actual honeypot test (`!empty($_POST['dontlook'])`) is also discarded. Practical effect:

- A bot that fills the hidden `dontlook` field — the thing the honeypot is supposed to catch — gets `$obvious_spam = false` (because `isset()` is true → `!isset()` is false), so no penalty is applied.
- A custom client that omits the field entirely (most legitimate clients won't, since the bundled form always renders it) triggers `$obvious_spam = true` and gets the `degree = 512` mega-ban — an unintended outcome.

## Fix

Use `&&`/`||` (which bind tighter than `=`) and parenthesize for clarity:

```php
\$in_period = (!empty(\$result) && time() < \$result['no_query_period']);
\$obvious_spam = (isset(\$_POST['dontlook']) && !empty(\$_POST['dontlook']));
```

The `\$obvious_spam` condition is also inverted to express the actually-intended logic: \"the honeypot field is **present** AND **non-empty**\".

## Impact

- No change for legitimate users: the bundled form always submits an empty `dontlook` field, so `\$obvious_spam` stays `false` (same as before, just via correct logic).
- Bots that fill the honeypot now actually receive the long ban.
- Returning users no longer get spurious \"in period\" rejections from stale rows whose timestamp has already elapsed.

## Repro

```
\$ php -r '\$result = [\"no_query_period\" => 0]; \$in_period = !empty(\$result) and time() < \$result[\"no_query_period\"]; var_dump(\$in_period);'
bool(true)        // wrong: timestamp is 0, \"in period\" should be false

\$ php -r '\$result = [\"no_query_period\" => 0]; \$in_period = (!empty(\$result) && time() < \$result[\"no_query_period\"]); var_dump(\$in_period);'
bool(false)       // correct
```

Found via static review of v2.3.1. (Replaces #217, which I closed to recreate from a clean fork.)