### PR TITLE
Fix Vyatta wrapper override by using late static binding

### DIFF
--- a/routers/quagga.php
+++ b/routers/quagga.php
@@ -29,7 +29,7 @@ class Quagga extends UNIX {
   protected function build_bgp($parameter, $routing_instance = false) {
     $cmd = new CommandBuilder();
     // vytsh commands need to be quoted
-    $cmd->add(self::$wrapper, '"', 'show');
+    $cmd->add(static::$wrapper, '"', 'show');
 
     if (match_ipv6($parameter, false)) {
       $cmd->add('ipv6');
@@ -45,7 +45,7 @@ class Quagga extends UNIX {
   protected function build_aspath_regexp($parameter, $routing_instance = false) {
     $commands = array();
     $cmd = new CommandBuilder();
-    $cmd->add(self::$wrapper);
+    $cmd->add(static::$wrapper);
 
     if (!$this->config['disable_ipv6']) {
       $commands[] = (clone $cmd)->add(escapeshellarg('show ipv6 bgp regexp '.$parameter));


### PR DESCRIPTION
## Problem

`Quagga::build_bgp()` and `Quagga::build_aspath_regexp()` reference [`self::$wrapper`](https://github.com/gmazoyer/looking-glass/blob/main/routers/quagga.php#L32), which is early-bound at parse time to the value `'vtysh -c'` defined on `Quagga`.

`Vyatta extends Quagga` and overrides:

```php
protected static \$wrapper = '/opt/vyatta/bin/vyatta-op-cmd-wrapper';
```

But because the parent uses `self::`, the override never takes effect — a router configured with `type: vyatta` actually invokes `vtysh -c \"...\"` on the box instead of `vyatta-op-cmd-wrapper`. Silent for years, presumably caught only by anyone who actually tries the Vyatta type and sees confusing command-not-found errors (or worse, accidentally running vtysh on a host where it does exist).

## Fix

Switch to `static::\$wrapper` so PHP late-static-binding resolves the wrapper at call time to the actual subclass. One-character change in two spots in `quagga.php`.

## Impact

- **Quagga**: no change — `static::\$wrapper` still resolves to `'vtysh -c'`.
- **Vyatta**: now actually uses the configured wrapper path.

## Follow-up

The same `self::\$wrapper` early-binding pattern is present in `vyos.php`, `frr.php`, and `extreme_netiron.php`. None of those currently have subclasses, so there's no behavioural change to fix today — but the footgun is still there for any future override. Happy to send a follow-up PR converting those too if you'd like to be consistent. Kept out of this PR to keep the diff minimal and the intent obvious.