### PR TITLE
Fix Mikrotik / Mikrotik 7 src-address separator

### DIFF
--- a/routers/mikrotik.php
+++ b/routers/mikrotik.php
@@ -107,11 +107,10 @@ final class Mikrotik extends Router {
 
     if ($this->has_source_interface_id()) {
       if (is_valid_ip_address($this->get_source_interface_id())) {
-        $cmd->add('src-address=');
         if (match_ipv6($parameter)) {
-          $cmd->add($this->get_source_interface_id('ipv6'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv6'));
         } else {
-          $cmd->add($this->get_source_interface_id('ipv4'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv4'));
         }
       } else {
         $cmd->add('interface='.$this->get_source_interface_id());
@@ -140,11 +139,10 @@ final class Mikrotik extends Router {
 
     if ($this->has_source_interface_id()) {
       if (is_valid_ip_address($this->get_source_interface_id())) {
-        $cmd->add('src-address=');
         if (match_ipv6($parameter)) {
-          $cmd->add($this->get_source_interface_id('ipv6'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv6'));
         } else {
-          $cmd->add($this->get_source_interface_id('ipv4'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv4'));
         }
       } else {
         $cmd->add('interface='.$this->get_source_interface_id());

--- a/routers/mikrotik7.php
+++ b/routers/mikrotik7.php
@@ -129,11 +129,10 @@ final class Mikrotik7 extends Router {
 
     if ($this->has_source_interface_id()) {
       if (is_valid_ip_address($this->get_source_interface_id())) {
-        $cmd->add('src-address=');
         if (match_ipv6($parameter)) {
-          $cmd->add($this->get_source_interface_id('ipv6'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv6'));
         } else {
-          $cmd->add($this->get_source_interface_id('ipv4'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv4'));
         }
       } else {
         $cmd->add('interface='.$this->get_source_interface_id());
@@ -162,11 +161,10 @@ final class Mikrotik7 extends Router {
 
     if ($this->has_source_interface_id()) {
       if (is_valid_ip_address($this->get_source_interface_id())) {
-        $cmd->add('src-address=');
         if (match_ipv6($parameter)) {
-          $cmd->add($this->get_source_interface_id('ipv6'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv6'));
         } else {
-          $cmd->add($this->get_source_interface_id('ipv4'));
+          $cmd->add('src-address='.$this->get_source_interface_id('ipv4'));
         }
       } else {
         $cmd->add('interface='.$this->get_source_interface_id());


### PR DESCRIPTION
## Problem

When `source-interface-id` is configured as an **IP address** (rather than an interface name), [`build_ping()`](https://github.com/gmazoyer/looking-glass/blob/main/routers/mikrotik.php#L108-L118) and [`build_traceroute()`](https://github.com/gmazoyer/looking-glass/blob/main/routers/mikrotik.php#L141-L152) in `mikrotik.php` and the parallel methods in `mikrotik7.php` emit:

\`\`\`php
\$cmd->add('src-address=');
\$cmd->add(\$this->get_source_interface_id('ipv4'));
\`\`\`

`CommandBuilder::__toString()` joins added elements with its separator (default single space), so the resulting RouterOS command is:

\`\`\`
/tool/ping ... src-address= 1.2.3.4 ...
\`\`\`

with a space between `=` and the address — RouterOS rejects this with a syntax error. The interface variant on the `else` branch already concatenates correctly:

\`\`\`php
\$cmd->add('interface='.\$this->get_source_interface_id());
\`\`\`

## Fix

Move the `src-address=` prefix into the same `add()` call as the value, matching the pattern already used for `address=` and `interface=`:

\`\`\`php
if (match_ipv6(\$parameter)) {
  \$cmd->add('src-address='.\$this->get_source_interface_id('ipv6'));
} else {
  \$cmd->add('src-address='.\$this->get_source_interface_id('ipv4'));
}
\`\`\`

## Affected configs

Any Mikrotik (RouterOS 6) or Mikrotik 7 router with `source-interface-id` set to an IPv4 or IPv6 **literal**. Configs using an interface name (the more common case) are unaffected.

## Smoke test

Before:
\`\`\`
/tool/ping count=1 address=8.8.8.8 src-address= 10.0.0.1
syntax error (line 1 column 56)
\`\`\`

After:
\`\`\`
/tool/ping count=1 address=8.8.8.8 src-address=10.0.0.1
SEQ HOST                                     SIZE TTL TIME  STATUS
  0 8.8.8.8                                    56  56 5ms   
\`\`\`