### PR TITLE
Fix ReferenceError on Reset/backhome when grecaptcha is undefined

### DIFF
--- a/js/looking-glass.js
+++ b/js/looking-glass.js
@@ -37,7 +37,7 @@ $(document).ready(function () {
     // reset the form and update the doc modal
     $(this).closest('form').get(0).reset();
     request_doc($('#query').val());
-    if (typeof grecaptcha.reset === "function") {
+    if (typeof grecaptcha !== "undefined" && typeof grecaptcha.reset === "function") {
       grecaptcha.reset();
     }
   });
@@ -46,7 +46,7 @@ $(document).ready(function () {
   $('#backhome').click(function () {
     $('.content').slideDown();
     $('.result').slideUp();
-    if (typeof grecaptcha.reset === "function") {
+    if (typeof grecaptcha !== "undefined" && typeof grecaptcha.reset === "function") {
       grecaptcha.reset();
     }
   });


### PR DESCRIPTION
## Problem

In [`js/looking-glass.js`](https://github.com/gmazoyer/looking-glass/blob/main/js/looking-glass.js#L40-L42):

\`\`\`js
if (typeof grecaptcha.reset === \"function\") {
  grecaptcha.reset();
}
\`\`\`

`typeof grecaptcha.reset` evaluates `grecaptcha.reset` first — which dereferences the `grecaptcha` identifier before `typeof` is applied to the result. When no reCAPTCHA script is loaded (captcha disabled, or hCaptcha is the configured type and provides the `hcaptcha` global instead), the identifier is undefined and the expression throws **ReferenceError**, aborting the click handler mid-execution.

The two affected handlers are the inline form Reset button (line 40) and the `#backhome` button (line 49). On captcha-disabled deployments the user sees Reset / \"Back to home\" do nothing on the first click after a query, with a `ReferenceError: grecaptcha is not defined` in the browser console.

## Fix

Guard with the standard `typeof` idiom for \"is this global defined\":

\`\`\`js
if (typeof grecaptcha !== \"undefined\" && typeof grecaptcha.reset === \"function\") {
  grecaptcha.reset();
}
\`\`\`

`typeof` on an undeclared identifier returns the string `\"undefined\"` without throwing, which is exactly the case we need to handle here.

## Impact

- **Captcha disabled / hCaptcha configured**: Reset and Back-home buttons work again.
- **reCAPTCHA enabled**: no change — both clauses are true, `grecaptcha.reset()` still called.