### PR TITLE
Quality cleanup: 5 small fixes (dead code, control flow, missing defaults)

### DIFF
--- a/includes/command_builder.php
+++ b/includes/command_builder.php
@@ -30,17 +30,6 @@ class CommandBuilder {
   }
 
   /**
-   * Breaks down an element into smaller one using the instance separator as
-   * delimiter.
-   *
-   * @param  string $element the element to break down.
-   * @return array  an array containing sub-elements.
-   */
-  private function breakdown_element($element) {
-    return explode($this->separator, $element);
-  }
-
-  /**
    * Adds given parameters to the command.
    *
    * There are no parameters in this function signature but it stil uses them.

--- a/includes/command_builder.php
+++ b/includes/command_builder.php
@@ -49,11 +49,10 @@ class CommandBuilder {
    *                separator.
    */
   public function __toString() {
-    $string = '';
-    foreach ($this->elements as $element) {
-      $string .= $this->separator.$element;
+    if (empty($this->elements)) {
+      return '';
     }
-    return $string;
+    return $this->separator.implode($this->separator, $this->elements);
   }
 }
 

--- a/includes/config.defaults.php
+++ b/includes/config.defaults.php
@@ -29,7 +29,10 @@ function set_defaults_for_routers(&$parsed_config) {
     'timeout' => 30,
     'disable_ipv6' => false,
     'disable_ipv4' => false,
-    'bgp_detail' => false
+    'bgp_detail' => false,
+    'blackhole' => false,
+    'filtered' => false,
+    'disabled' => false
   );
 
   // Loads defaults when key does not exist

--- a/index.php
+++ b/index.php
@@ -54,16 +54,17 @@ final class LookingGlass {
   }
 
   private function command_count() {
-    if ($this->frontpage['command_count'] > 0)
+    if ($this->frontpage['command_count'] > 0) {
       return $this->frontpage['command_count'];
-    else
-      $command_count = 0;
-      foreach (array_keys($this->doc) as $cmd) {
-        if (isset($this->doc[$cmd]['command'])) {
-          $command_count++;
-        }
+    }
+
+    $command_count = 0;
+    foreach (array_keys($this->doc) as $cmd) {
+      if (isset($this->doc[$cmd]['command'])) {
+        $command_count++;
       }
-      return $command_count;
+    }
+    return $command_count;
   }
 
   private function render_routers() {

--- a/routers/cisco.php
+++ b/routers/cisco.php
@@ -96,10 +96,10 @@ class Cisco extends Router {
       }
 
       if (match_ipv6($parameter)) {
-        $cmd->add('ipv6', (isset($hostname) ? $hostname : $parameter));
+        $cmd->add('ipv6', $hostname);
       }
       if (match_ipv4($parameter)) {
-        $cmd->add('ip', (isset($hostname) ? $hostname : $parameter));
+        $cmd->add('ip', $hostname);
       }
     }
 

--- a/routers/cisco_iosxr.php
+++ b/routers/cisco_iosxr.php
@@ -80,10 +80,10 @@ final class IOSXR extends Cisco {
       }
 
       if (match_ipv6($parameter)) {
-        $cmd->add('ipv6', (isset($hostname) ? $hostname : $parameter));
+        $cmd->add('ipv6', $hostname);
       }
       if (match_ipv4($parameter)) {
-        $cmd->add('ipv4', (isset($hostname) ? $hostname : $parameter));
+        $cmd->add('ipv4', $hostname);
       }
     }
 
@@ -129,10 +129,10 @@ final class IOSXR extends Cisco {
       }
 
       if (match_ipv6($parameter)) {
-        $cmd->add('ipv6', (isset($hostname) ? $hostname : $parameter));
+        $cmd->add('ipv6', $hostname);
       }
       if (match_ipv4($parameter)) {
-        $cmd->add('ipv4', (isset($hostname) ? $hostname : $parameter));
+        $cmd->add('ipv4', $hostname);
       }
     }
 

--- a/routers/extreme_netiron.php
+++ b/routers/extreme_netiron.php
@@ -100,7 +100,7 @@ final class ExtremeNetIron extends Router {
       if (match_ipv6($parameter)) {
         $cmd->add('ipv6');
       }
-      $cmd->add(isset($hostname) ? $hostname : $parameter);
+      $cmd->add($hostname);
     } else {
       if (match_ipv6($parameter)) {
         $cmd->add('ipv6');
@@ -141,7 +141,7 @@ final class ExtremeNetIron extends Router {
       if (match_ipv6($parameter)) {
         $cmd->add('ipv6');
       }
-      $cmd->add(isset($hostname) ? $hostname : $parameter);
+      $cmd->add($hostname);
     } else {
       if (match_ipv6($parameter)) {
         $cmd->add('ipv6');

--- a/routers/huawei.php
+++ b/routers/huawei.php
@@ -115,10 +115,10 @@ class Huawei extends Router {
       }
 
       if (match_ipv6($parameter)) {
-        $cmd->add('ipv6', (isset($hostname) ? $hostname : $parameter));
+        $cmd->add('ipv6', $hostname);
       }
       if (match_ipv4($parameter)) {
-        $cmd->add((isset($hostname) ? $hostname : $parameter));
+        $cmd->add($hostname);
       }
     }
 

--- a/routers/mikrotik7.php
+++ b/routers/mikrotik7.php
@@ -110,7 +110,6 @@ final class Mikrotik7 extends Router {
     }
 
     return array($cmd);
-    //return $commands;
   }
 
   protected function build_ping($parameter, $routing_instance = false) {


### PR DESCRIPTION
A batch of small, independent quality fixes found during a static review pass — each as its own commit so you can cherry-pick if you'd rather not take all of them.

## Commits

### 1. `Fix command_count() control flow — else block missing braces` (index.php)
`Index::command_count()` had an unbraced `else` whose body looked multi-line but only covered the first statement. The `foreach` counter loop and the trailing `return $command_count;` were actually unconditional. The function still returned the right value end-to-end thanks to the early return in the `if`-branch, but the code was misleading. Replaced with the same shape as `router_count()` directly above.

### 2. `Remove unused private CommandBuilder::breakdown_element()` (includes/command_builder.php)
`grep -rn breakdown_element` shows only the definition — no callers anywhere in the repo. Dead code since at least v2.0.0.

### 3. `Simplify CommandBuilder::__toString() with implode()` (includes/command_builder.php)
Replaced the hand-rolled foreach with `implode()`. Kept the explicit leading-separator prefix (`$this->separator.implode(...)`) so the output is **bit-identical** to the previous implementation for all non-empty element lists — no behavioural change for any caller, just less code.

### 4. `mikrotik7: declare blackhole/filtered/disabled defaults and remove stale comment` (config.defaults.php, mikrotik7.php)
`Mikrotik7::build_bgp/aspath_regexp/build_as` all read `$this->config['blackhole']`, `'filtered'`, and `'disabled'` to decide whether to suppress those route types, but these keys aren't declared in `set_defaults_for_routers()`. On default Mikrotik 7 deployments PHP emits an "Undefined array key" warning per query (PHP 8.x) and the unset values coerce to falsy → all three filters fire. Added `false` defaults next to `bgp_detail`. Behaviour unchanged for existing users; warnings stop; users can now opt-in to including those route types by setting any of them to `true`. Also removed a leftover `//return $commands;` comment in `Mikrotik7::build_as()` from an old refactor.

### 5. `Remove redundant isset($hostname) ternary in routers` (cisco/cisco_iosxr/extreme_netiron/huawei)
In the hostname-resolution branches of these routers, `$hostname = $parameter` is set unconditionally before the inner `$cmd->add(..., (isset($hostname) ? $hostname : $parameter))` is reached. The ternary defends against a path that can't happen. Replaced with plain `$hostname`. `unix.php` has the same expression but a different structure — there `$hostname` IS conditionally set, so the guard is real and necessary. Left alone.

---

All five are small and independent. Happy to split into separate PRs if you'd prefer per-issue review.